### PR TITLE
make VMProvider.Exists return *bool to allow "not applicable"

### DIFF
--- a/pkg/machine/applehv/stubber.go
+++ b/pkg/machine/applehv/stubber.go
@@ -86,9 +86,9 @@ func (a *AppleHVStubber) CreateVM(opts define.CreateVMOpts, mc *vmconfigs.Machin
 	return apple.ResizeDisk(mc, mc.Resources.DiskSize)
 }
 
-func (a *AppleHVStubber) Exists(_ string) (bool, error) {
+func (a *AppleHVStubber) Exists(_ string) (*bool, error) {
 	// not applicable for applehv
-	return false, nil
+	return nil, nil
 }
 
 func (a *AppleHVStubber) MountType() vmconfigs.VolumeMountType {

--- a/pkg/machine/hyperv/stubber.go
+++ b/pkg/machine/hyperv/stubber.go
@@ -164,10 +164,10 @@ func (h HyperVStubber) CreateVM(opts define.CreateVMOpts, mc *vmconfigs.MachineC
 	return err
 }
 
-func (h HyperVStubber) Exists(name string) (bool, error) {
+func (h HyperVStubber) Exists(name string) (*bool, error) {
 	vmm := hypervctl.NewVirtualMachineManager()
 	exists, _, err := vmm.GetMachineExists(name)
-	return exists, err
+	return &exists, err
 }
 
 func (h HyperVStubber) MountType() vmconfigs.VolumeMountType {

--- a/pkg/machine/libkrun/stubber.go
+++ b/pkg/machine/libkrun/stubber.go
@@ -64,9 +64,9 @@ func (l *LibKrunStubber) PrepareIgnition(_ *vmconfigs.MachineConfig, _ *ignition
 	return nil, nil
 }
 
-func (l *LibKrunStubber) Exists(_ string) (bool, error) {
+func (l *LibKrunStubber) Exists(_ string) (*bool, error) {
 	// not applicable for libkrun (same as applehv)
-	return false, nil
+	return nil, nil
 }
 
 func (l *LibKrunStubber) MountType() vmconfigs.VolumeMountType {

--- a/pkg/machine/qemu/stubber.go
+++ b/pkg/machine/qemu/stubber.go
@@ -264,8 +264,8 @@ func waitForReady(readySocket *define.VMFile, pid int, stdErrBuffer *bytes.Buffe
 	return err
 }
 
-func (q *QEMUStubber) Exists(_ string) (bool, error) {
-	return false, nil
+func (q *QEMUStubber) Exists(_ string) (*bool, error) {
+	return nil, nil
 }
 
 func (q *QEMUStubber) VMType() define.VMType {

--- a/pkg/machine/shim/host.go
+++ b/pkg/machine/shim/host.go
@@ -322,6 +322,7 @@ func Init(opts machineDefine.InitOptions, mp vmconfigs.VMProvider) error {
 //  3. External VM: VM already exists on hypervisor but no config, so it was not created by podman -> returns (nil, true, error)
 //  4. Hypervisor error with config: Config exists but hypervisor check fails -> returns (config, true, nil)
 //     (config is trusted, warning is logged)
+//  5. VM does not exist on hypervisor and no config -> returns (nil, false, nil)
 func VMExists(name string, vmstubbers []vmconfigs.VMProvider) (*vmconfigs.MachineConfig, bool, error) {
 	// Look on disk first
 	mcs, err := getMCsOverProviders(vmstubbers)
@@ -345,13 +346,30 @@ func VMExists(name string, vmstubbers []vmconfigs.VMProvider) (*vmconfigs.Machin
 			}
 			return nil, false, err
 		}
-		if exists {
-			if hasConfig {
-				return mc.MachineConfig, true, nil
-			}
-			// VM exists in hypervisor but no local config - it was created by something else
-			return nil, true, fmt.Errorf("vm %q already exists on hypervisor", name)
+
+		// If the provider explicitly said that the VM doesn't exist, we can return early
+		if exists != nil && !*exists {
+			return nil, false, nil
 		}
+
+		// At this point: The VM exists or the provider (e.g. applehv, libkrun and qemu)
+		// doesn't support the exists check, so we trust the config.
+		// If we have a config, we have a VM.
+		if hasConfig {
+			return mc.MachineConfig, true, nil
+		}
+
+		// Here: we know the Podman VM does not exist as there is no config -
+		// however a VM with that name may exist.
+		// We must handle two cases:
+		// 1. the provider does not support the exists check, so we can say the VM does not exist
+		// 2. the provider supports the exists check, it responded that the VM exists but there is no config
+		//    for it, so it must have been created by something else (e.g. a user created it using HyperV Manager).
+		if exists == nil {
+			return nil, false, nil // VM does not exist
+		}
+
+		return nil, true, fmt.Errorf("vm %q already exists on hypervisor", name) // VM exists on hypervisor but we have no local config
 	}
 	return nil, false, nil
 }

--- a/pkg/machine/vmconfigs/config.go
+++ b/pkg/machine/vmconfigs/config.go
@@ -71,7 +71,7 @@ type CloudInitConfig struct {
 type VMProvider interface { //nolint:interfacebloat
 	CreateVM(opts define.CreateVMOpts, mc *MachineConfig, builder *ignition.IgnitionBuilder) error
 	PrepareIgnition(mc *MachineConfig, ignBuilder *ignition.IgnitionBuilder) (*ignition.ReadyUnitOpts, error)
-	Exists(name string) (bool, error)
+	Exists(name string) (*bool, error)
 	MountType() VolumeMountType
 	MountVolumesToVM(mc *MachineConfig, quiet bool) error
 	Remove(mc *MachineConfig) ([]string, func() error, error)

--- a/pkg/machine/wsl/stubber.go
+++ b/pkg/machine/wsl/stubber.go
@@ -105,8 +105,9 @@ func (w WSLStubber) PrepareIgnition(_ *vmconfigs.MachineConfig, _ *ignition.Igni
 	return nil, nil
 }
 
-func (w WSLStubber) Exists(name string) (bool, error) {
-	return isWSLExist(env.WithToolPrefix(name))
+func (w WSLStubber) Exists(name string) (*bool, error) {
+	exists, err := isWSLExist(env.WithToolPrefix(name))
+	return &exists, err
 }
 
 func (w WSLStubber) MountType() vmconfigs.VolumeMountType {


### PR DESCRIPTION
Change the Exists method in the VMProvider interface from (bool, error) to (*bool, error) so we can use the nil value to indicate the Exists check is not applicable for a specific provider.

Before, applehv, libkrun and qemu were returning false, even though they were not performing any check and this could cause misunderstanding.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized existence checks across machine providers to return an optional boolean, improving clarity when a provider cannot determine applicability.
* **Bug Fix**
  * Improved VM existence logic to distinctly handle provider-confirmed non-existence, presence of local configuration, and "exists without local config" scenarios for more accurate reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->