### PR TITLE
try alternative QEMU binary names

### DIFF
--- a/pkg/machine/provider/platform_unix.go
+++ b/pkg/machine/provider/platform_unix.go
@@ -3,9 +3,7 @@
 package provider
 
 import (
-	"errors"
 	"fmt"
-	"io/fs"
 	"os"
 
 	"github.com/containers/podman/v5/pkg/machine/define"
@@ -50,19 +48,9 @@ func SupportedProviders() []define.VMType {
 func IsInstalled(provider define.VMType) (bool, error) {
 	switch provider {
 	case define.QemuVirt:
-		cfg, err := config.Default()
+		_, err := qemu.FindQEMUBinary()
 		if err != nil {
-			return false, err
-		}
-		if cfg == nil {
-			return false, fmt.Errorf("error fetching getting default config")
-		}
-		_, err = cfg.FindHelperBinary(qemu.QemuCommand, true)
-		if errors.Is(err, fs.ErrNotExist) {
 			return false, nil
-		}
-		if err != nil {
-			return false, err
 		}
 		return true, nil
 	default:

--- a/pkg/machine/qemu/config.go
+++ b/pkg/machine/qemu/config.go
@@ -3,6 +3,8 @@
 package qemu
 
 import (
+	"fmt"
+
 	"go.podman.io/common/pkg/config"
 )
 
@@ -12,11 +14,19 @@ import (
 // TODO Podman5
 type setNewMachineCMDOpts struct{}
 
-// findQEMUBinary locates and returns the QEMU binary
-func findQEMUBinary() (string, error) {
+// FindQEMUBinary locates and returns the QEMU binary by trying each name
+// in qemuCommand in order. On most distros the first entry (e.g.
+// "qemu-system-x86_64") will match; on RHEL/CentOS the binary is packaged
+// as "qemu-kvm" instead, which is listed as a later entry.
+func FindQEMUBinary() (string, error) {
 	cfg, err := config.Default()
 	if err != nil {
 		return "", err
 	}
-	return cfg.FindHelperBinary(QemuCommand, true)
+	for _, name := range qemuCommand {
+		if binary, e := cfg.FindHelperBinary(name, true); e == nil {
+			return binary, nil
+		}
+	}
+	return "", fmt.Errorf("unable to find any QEMU binary: tried %v", qemuCommand)
 }

--- a/pkg/machine/qemu/options_freebsd_amd64.go
+++ b/pkg/machine/qemu/options_freebsd_amd64.go
@@ -2,9 +2,7 @@
 
 package qemu
 
-var (
-	QemuCommand = "qemu-system-x86_64"
-)
+var qemuCommand = []string{"qemu-system-x86_64"}
 
 func (q *QEMUStubber) addArchOptions(_ *setNewMachineCMDOpts) []string {
 	opts := []string{"-machine", "q35,accel=hvf:tcg", "-cpu", "host"}

--- a/pkg/machine/qemu/options_freebsd_arm64.go
+++ b/pkg/machine/qemu/options_freebsd_arm64.go
@@ -2,9 +2,7 @@
 
 package qemu
 
-var (
-	QemuCommand = "qemu-system-aarch64"
-)
+var qemuCommand = []string{"qemu-system-aarch64"}
 
 func (q *QEMUStubber) addArchOptions(_ *setNewMachineCMDOpts) []string {
 	opts := []string{

--- a/pkg/machine/qemu/options_linux_amd64.go
+++ b/pkg/machine/qemu/options_linux_amd64.go
@@ -2,9 +2,7 @@
 
 package qemu
 
-var (
-	QemuCommand = "qemu-system-x86_64"
-)
+var qemuCommand = []string{"qemu-system-x86_64", "qemu-kvm"}
 
 func (q *QEMUStubber) addArchOptions(_ *setNewMachineCMDOpts) []string {
 	opts := []string{

--- a/pkg/machine/qemu/options_linux_arm64.go
+++ b/pkg/machine/qemu/options_linux_arm64.go
@@ -8,9 +8,7 @@ import (
 	"go.podman.io/storage/pkg/fileutils"
 )
 
-var (
-	QemuCommand = "qemu-system-aarch64"
-)
+var qemuCommand = []string{"qemu-system-aarch64", "qemu-kvm"}
 
 func (q *QEMUStubber) addArchOptions(_ *setNewMachineCMDOpts) []string {
 	opts := []string{

--- a/pkg/machine/qemu/options_windows_amd64.go
+++ b/pkg/machine/qemu/options_windows_amd64.go
@@ -2,9 +2,7 @@
 
 package qemu
 
-var (
-	QemuCommand = "qemu-system-x86_64w"
-)
+var qemuCommand = []string{"qemu-system-x86_64w"}
 
 func (q *QEMUStubber) addArchOptions(_ *setNewMachineCMDOpts) []string {
 	// "qemu64" level is used, because "host" is not supported with "whpx" acceleration.

--- a/pkg/machine/qemu/options_windows_arm64.go
+++ b/pkg/machine/qemu/options_windows_arm64.go
@@ -2,9 +2,7 @@
 
 package qemu
 
-var (
-	QemuCommand = "qemu-system-aarch64w"
-)
+var qemuCommand = []string{"qemu-system-aarch64w"}
 
 func (q *QEMUStubber) addArchOptions(_ *setNewMachineCMDOpts) []string {
 	// stub to fix compilation issues

--- a/pkg/machine/qemu/stubber.go
+++ b/pkg/machine/qemu/stubber.go
@@ -58,7 +58,7 @@ func (q *QEMUStubber) RequireExclusiveActive() bool {
 }
 
 func (q *QEMUStubber) setQEMUCommandLine(mc *vmconfigs.MachineConfig) error {
-	qemuBinary, err := findQEMUBinary()
+	qemuBinary, err := FindQEMUBinary()
 	if err != nil {
 		return err
 	}
@@ -136,11 +136,7 @@ func runStartVMCommand(cmd *exec.Cmd) error {
 	if err != nil {
 		// check if qemu was not found
 		// look up qemu again maybe the path was changed, https://github.com/containers/podman/issues/13394
-		cfg, err := config.Default()
-		if err != nil {
-			return err
-		}
-		qemuBinaryPath, err := cfg.FindHelperBinary(QemuCommand, true)
+		qemuBinaryPath, err := FindQEMUBinary()
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
On RHEL/CentOS, QEMU is packaged as "qemu-kvm" rather than "qemu-system-x86_64", so macadam (that is built over podman) fails to find the binary unless the user manually creates a symlink. (ref.
https://github.com/crc-org/macadam/issues/176)

Change QemuCommand from a single string to a slice of candidate binary names, tried in order. On Linux, this adds "qemu-kvm" as an alternative after the standard "qemu-system-*" name. Other platforms are unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved QEMU detection to try multiple command names and unify lookup behavior.
  * Simplified platform checks and removed noisy error propagation when QEMU isn't present.
  * More consistent handling across platforms, reducing spurious failures during VM start and initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->