### PR TITLE
wsl: restart sshd in bootstrap to apply port reassignments

### DIFF
--- a/pkg/machine/wsl/declares.go
+++ b/pkg/machine/wsl/declares.go
@@ -50,6 +50,9 @@ const sudoers = `%wheel        ALL=(ALL)       NOPASSWD: ALL
 `
 
 const bootstrapSystemdConfig = `#!/bin/bash
+# Sometimes we need to reassign ssh port, and we have to make sure sshd is running with it
+# https://github.com/crc-org/macadam/issues/368
+systemctl restart sshd
 nohup bash -c 'while true; do sleep 60; done' >/dev/null 2>&1 &
 `
 


### PR DESCRIPTION
When a port conflict is detected during macadam start, the SSH port is reassigned and updated in the guest's /etc/ssh/sshd_config via a sed command. However, when updating the config, the WSL instance gets started automatically and SSH service with it, just before this reassignment occurs.

This resulted in a state mismatch where the configuration file specified a new port, but the active sshd process remained bound to the old one, leading to connection timeouts and e2e test failures.

This change updates the bootstrapSystemdConfig script to explicitly restart the sshd service.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SSH service initialization to enhance remote access reliability in WSL environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->